### PR TITLE
Change docs main page to README

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Kino.MixProject do
 
   defp docs do
     [
-      main: "examples",
+      main: "readme",
       source_url: "https://github.com/elixir-nx/kino",
       source_ref: "v#{@version}",
       extras: [


### PR DESCRIPTION
I think examples is a great starting point but given it's common to start with a README, there is the license information, and we have the convenient "Next" button to go to examples, I thought I'd open it up. But yeah, happy to leave things as is, just curious :)
