### PR TITLE
Return the Vl widget on periodically

### DIFF
--- a/lib/kino/vega_lite.ex
+++ b/lib/kino/vega_lite.ex
@@ -112,9 +112,10 @@ defmodule Kino.VegaLite do
 
   The callback is run for the first time immediately upon registration.
   """
-  @spec periodically(t(), pos_integer(), term(), (term() -> {:cont, term()} | :halt)) :: :ok
+  @spec periodically(t(), pos_integer(), term(), (term() -> {:cont, term()} | :halt)) :: t()
   def periodically(widget, interval_ms, acc, fun) do
     GenServer.cast(widget.pid, {:periodically, interval_ms, acc, fun})
+    widget
   end
 
   @impl true

--- a/test/kino/vega_lite_test.exs
+++ b/test/kino/vega_lite_test.exs
@@ -64,14 +64,14 @@ defmodule Kino.VegaLiteTest do
 
     connect_self(widget)
 
-    Kino.VegaLite.periodically(widget, 1, 1, fn n ->
-      if n < 3 do
-        Kino.VegaLite.push(widget, %{x: n, y: n})
-        {:cont, n + 1}
-      else
-        :halt
-      end
-    end)
+    assert Kino.VegaLite.periodically(widget, 1, 1, fn n ->
+             if n < 3 do
+               Kino.VegaLite.push(widget, %{x: n, y: n})
+               {:cont, n + 1}
+             else
+               :halt
+             end
+           end) == widget
 
     assert_receive {:push, %{data: [%{x: 1, y: 1}], dataset: nil, window: nil}}
     assert_receive {:push, %{data: [%{x: 2, y: 2}], dataset: nil, window: nil}}


### PR DESCRIPTION
This way, in Livebook, instead of

    widget =
      Vl.new(...)
      |> ...
      |> Kino.VegaLite.start()
      |> Kino.render()

    Kino.VegaLite.periodically(widget, ...)

we can do

    Vl.new(...)
    |> ...
    |> Kino.VegaLite.start()
    |> Kino.VegaLite.periodically(...)

Should we do the same for push/clear/etc?