### PR TITLE
Add dynamic table output and ETS table widget

### DIFF
--- a/lib/kino/ets.ex
+++ b/lib/kino/ets.ex
@@ -68,13 +68,19 @@ defmodule Kino.ETS do
 
   @impl true
   def handle_info({:connect, pid}, state) do
+    table_name = :ets.info(state.tid, :name)
+    name = "ETS #{inspect(table_name)}"
+
     columns =
       case :ets.match_object(state.tid, :_, 1) do
         {[record], _} -> columns_structure_from_record(record)
         :"$end_of_table" -> []
       end
 
-    send(pid, {:connect_reply, %{columns: columns, features: [:pagination, :sorting]}})
+    send(
+      pid,
+      {:connect_reply, %{name: name, columns: columns, features: [:pagination, :sorting]}}
+    )
 
     {:noreply, state}
   end

--- a/lib/kino/ets.ex
+++ b/lib/kino/ets.ex
@@ -1,0 +1,145 @@
+defmodule Kino.ETS do
+  @moduledoc """
+  A widget for interactively viewing an ETS table.
+
+  ## Examples
+
+      tid = :ets.new(:users, [:set, :public])
+      Kino.ETS.start(tid)
+
+      Kino.ETS.start(:elixir_config)
+  """
+
+  use GenServer, restart: :temporary
+
+  defstruct [:pid]
+
+  @type t :: %__MODULE__{pid: pid()}
+
+  @typedoc false
+  @type state :: %{
+          parent_monitor_ref: reference(),
+          tid: :ets.tid()
+        }
+
+  @doc """
+  Starts a widget process representing the given ETS table.
+
+  Note that private tables cannot be read by an arbitrary process,
+  so the given table must have either public or protected access.
+  """
+  @spec start(:ets.tid()) :: t()
+  def start(tid) do
+    case :ets.info(tid, :protection) do
+      :private ->
+        raise ArgumentError,
+              "the given table must be either public or protected, but a private one was given"
+
+      :undefined ->
+        raise ArgumentError,
+              "the given table identifier #{inspect(tid)} does not refer to an existing ETS table"
+
+      _ ->
+        :ok
+    end
+
+    parent = self()
+    opts = [tid: tid, parent: parent]
+
+    {:ok, pid} = DynamicSupervisor.start_child(Kino.WidgetSupervisor, {__MODULE__, opts})
+
+    %__MODULE__{pid: pid}
+  end
+
+  @doc false
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @impl true
+  def init(opts) do
+    tid = Keyword.fetch!(opts, :tid)
+    parent = Keyword.fetch!(opts, :parent)
+
+    parent_monitor_ref = Process.monitor(parent)
+
+    {:ok, %{parent_monitor_ref: parent_monitor_ref, tid: tid}}
+  end
+
+  @impl true
+  def handle_info({:connect, pid}, state) do
+    columns =
+      case :ets.match_object(state.tid, :_, 1) do
+        {[record], _} -> columns_structure_from_record(record)
+        :"$end_of_table" -> []
+      end
+
+    send(pid, {:connect_reply, %{columns: columns, features: [:pagination, :sorting]}})
+
+    {:noreply, state}
+  end
+
+  def handle_info({:get_rows, pid, rows_spec}, state) do
+    records = get_records(state.tid, rows_spec)
+    rows = Enum.map(records, &record_to_row/1)
+    total_rows = :ets.info(state.tid, :size)
+
+    columns =
+      case records do
+        [] -> :initial
+        [record | _] -> columns_structure_from_record(record)
+      end
+
+    send(pid, {:rows, %{rows: rows, total_rows: total_rows, columns: columns}})
+
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, _object, _reason}, %{parent_monitor_ref: ref} = state) do
+    {:stop, :shutdown, state}
+  end
+
+  defp columns_structure_from_record(record) do
+    record
+    |> Tuple.to_list()
+    |> Enum.with_index()
+    |> Enum.map(fn {_, idx} ->
+      %{key: idx, label: "#{idx + 1}"}
+    end)
+  end
+
+  defp get_records(tid, rows_spec) do
+    query = :ets.table(tid)
+
+    order_by_pos = (rows_spec[:order_by] || 0) + 1
+
+    order =
+      case rows_spec.order do
+        :asc -> :ascending
+        :desc -> :descending
+      end
+
+    query = :qlc.keysort(order_by_pos, query, order: order)
+
+    cursor = :qlc.cursor(query)
+
+    if rows_spec.offset > 0 do
+      :qlc.next_answers(cursor, rows_spec.offset)
+    end
+
+    records = :qlc.next_answers(cursor, rows_spec.limit)
+    :qlc.delete_cursor(cursor)
+    records
+  end
+
+  defp record_to_row(record) do
+    fields =
+      record
+      |> Tuple.to_list()
+      |> Enum.with_index()
+      |> Map.new(fn {val, idx} -> {idx, inspect(val)} end)
+
+    # Note: id is opaque to the client, and we don't need it for now
+    %{id: nil, fields: fields}
+  end
+end

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -80,6 +80,7 @@ defmodule Kino.Output do
       }
 
       {:connect_reply, %{
+        name: binary(),
         columns: list(column()),
         features: list(:pagination | :sorting)
       }}

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -12,6 +12,7 @@ defmodule Kino.Output do
           | text_block()
           | vega_lite_static()
           | vega_lite_dynamic()
+          | table_dynamic()
 
   @typedoc """
   An empty output that should be ignored whenever encountered.
@@ -47,7 +48,7 @@ defmodule Kino.Output do
 
   A client process should connect to the server process by sending:
 
-      {:connect, pid}
+      {:connect, pid()}
 
   And expect the following reply:
 
@@ -58,6 +59,59 @@ defmodule Kino.Output do
       {:push, %{data: list(), dataset: binary(), window: non_neg_integer()}}
   """
   @type vega_lite_dynamic :: {:vega_lite_dynamic, pid()}
+
+  @typedoc """
+  Interactive data table.
+
+  There should be a server process that serves data requests,
+  filtering, sorting and slicing data as necessary.
+
+  ## Communication protocol
+
+  A client process should connect to the server process by sending:
+
+      {:connect, pid()}
+
+  And expect the following reply:
+
+      @type column :: %{
+        key: term(),
+        label: binary()
+      }
+
+      {:connect_reply, %{
+        columns: list(column()),
+        features: list(:pagination | :sorting)
+      }}
+
+  The client may then query for table rows by sending the following requests:
+
+      @type rows_spec :: %{
+        offset: non_neg_integer(),
+        limit: pos_integer(),
+        order_by: nil | term(),
+        order: :asc | :desc,
+      }
+
+      {:get_rows, pid(), rows_spec()}
+
+  To which the server responds with retrieved data:
+
+      @type row :: %{
+        # An identifier, opaque to the client
+        id: term(),
+        # A string value for every column key
+        fields: list(%{term() => binary()})
+      }
+
+      {:rows, %{
+        rows: list(row()),
+        total_rows: non_neg_integer(),
+        # Possibly an updated columns specification
+        columns: :initial | list(column())
+      }}
+  """
+  @type table_dynamic :: {:table_dynamic, pid()}
 
   @doc """
   See `t:text_inline/0`.
@@ -89,6 +143,14 @@ defmodule Kino.Output do
   @spec vega_lite_dynamic(pid()) :: t()
   def vega_lite_dynamic(pid) when is_pid(pid) do
     {:vega_lite_dynamic, pid}
+  end
+
+  @doc """
+  See `t:table_dynamic/0`.
+  """
+  @spec table_dynamic(pid()) :: t()
+  def table_dynamic(pid) when is_pid(pid) do
+    {:table_dynamic, pid}
   end
 
   @doc """

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -32,6 +32,33 @@ defimpl Kino.Render, for: Kino.ETS do
   end
 end
 
+# Elixir built-ins
+
+defimpl Kino.Render, for: Reference do
+  def to_livebook(reference) do
+    cond do
+      accessible_ets_table?(reference) ->
+        reference |> Kino.ETS.start() |> Kino.Render.to_livebook()
+
+      true ->
+        Kino.Output.inspect(reference)
+    end
+  end
+
+  defp accessible_ets_table?(reference) when is_reference(reference) do
+    try do
+      case :ets.info(reference, :protection) do
+        :undefined -> false
+        :private -> false
+        _ -> true
+      end
+    rescue
+      # When the reference is not a valid table identifier
+      ArgumentError -> false
+    end
+  end
+end
+
 # External packages
 
 defimpl Kino.Render, for: VegaLite do

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -26,6 +26,12 @@ defimpl Kino.Render, for: Kino.VegaLite do
   end
 end
 
+defimpl Kino.Render, for: Kino.ETS do
+  def to_livebook(widget) do
+    Kino.Output.table_dynamic(widget.pid)
+  end
+end
+
 # External packages
 
 defimpl Kino.Render, for: VegaLite do

--- a/lib/kino/vega_lite.ex
+++ b/lib/kino/vega_lite.ex
@@ -30,6 +30,7 @@ defmodule Kino.VegaLite do
 
   @typedoc false
   @type state :: %{
+          parent_monitor_ref: reference(),
           vl: VegaLite.t(),
           window: non_neg_integer(),
           datasets: %{binary() => list()},
@@ -39,7 +40,7 @@ defmodule Kino.VegaLite do
   @doc """
   Starts a widget process with the given VegaLite definition.
   """
-  @spec start(VegaLite.t()) :: Kino.VegaLite.t()
+  @spec start(VegaLite.t()) :: t()
   def start(vl) when is_struct(vl, VegaLite) do
     parent = self()
     opts = [vl: vl, parent: parent]

--- a/test/kino/ets_test.exs
+++ b/test/kino/ets_test.exs
@@ -1,0 +1,143 @@
+defmodule Kino.ETSTest do
+  use ExUnit.Case, async: true
+
+  describe "start/1" do
+    test "raises an error when private table is given" do
+      tid = :ets.new(:users, [:set, :private])
+
+      assert_raise ArgumentError,
+                   "the given table must be either public or protected, but a private one was given",
+                   fn ->
+                     Kino.ETS.start(tid)
+                   end
+    end
+
+    test "raises an error when non-existent table is given" do
+      tid = :ets.new(:users, [:set, :private])
+      :ets.delete(tid)
+
+      assert_raise ArgumentError,
+                   "the given table identifier #{inspect(tid)} does not refer to an existing ETS table",
+                   fn ->
+                     Kino.ETS.start(tid)
+                   end
+    end
+  end
+
+  describe "connecting" do
+    test "connect reply contains empty columns definition if there are no records" do
+      tid = :ets.new(:users, [:set, :public])
+
+      widget = Kino.ETS.start(tid)
+
+      send(widget.pid, {:connect, self()})
+
+      assert_receive {:connect_reply, %{columns: [], features: [:pagination, :sorting]}}
+    end
+
+    test "connect reply contains columns definition if there are some records" do
+      tid = :ets.new(:users, [:set, :public])
+      :ets.insert(tid, {1, "Terry Jeffords"})
+
+      widget = Kino.ETS.start(tid)
+
+      send(widget.pid, {:connect, self()})
+
+      assert_receive {:connect_reply,
+                      %{
+                        columns: [%{key: 0, label: "1"}, %{key: 1, label: "2"}],
+                        features: [:pagination, :sorting]
+                      }}
+    end
+  end
+
+  describe "querying rows" do
+    setup do
+      tid = :ets.new(:users, [:set, :public])
+
+      :ets.insert(tid, {3, "Amy Santiago"})
+      :ets.insert(tid, {1, "Jake Peralta"})
+      :ets.insert(tid, {2, "Terry Jeffords"})
+
+      {:ok, tid: tid}
+    end
+
+    test "orders results by key by default", %{tid: tid} do
+      widget = Kino.ETS.start(tid)
+      connect_self(widget)
+
+      spec = %{
+        offset: 0,
+        limit: 10,
+        order_by: nil,
+        order: :asc
+      }
+
+      send(widget.pid, {:get_rows, self(), spec})
+
+      assert_receive {:rows,
+                      %{
+                        rows: [
+                          %{id: _, fields: %{0 => "1", 1 => ~s/"Jake Peralta"/}},
+                          %{id: _, fields: %{0 => "2", 1 => ~s/"Terry Jeffords"/}},
+                          %{id: _, fields: %{0 => "3", 1 => ~s/"Amy Santiago"/}}
+                        ],
+                        total_rows: 3,
+                        columns: [_, _]
+                      }}
+    end
+
+    test "supports sorting by other columns", %{tid: tid} do
+      widget = Kino.ETS.start(tid)
+      connect_self(widget)
+
+      spec = %{
+        offset: 0,
+        limit: 10,
+        order_by: 1,
+        order: :desc
+      }
+
+      send(widget.pid, {:get_rows, self(), spec})
+
+      assert_receive {:rows,
+                      %{
+                        rows: [
+                          %{id: _, fields: %{0 => "2", 1 => ~s/"Terry Jeffords"/}},
+                          %{id: _, fields: %{0 => "1", 1 => ~s/"Jake Peralta"/}},
+                          %{id: _, fields: %{0 => "3", 1 => ~s/"Amy Santiago"/}}
+                        ],
+                        total_rows: 3,
+                        columns: [_, _]
+                      }}
+    end
+
+    test "supports offset and limit", %{tid: tid} do
+      widget = Kino.ETS.start(tid)
+      connect_self(widget)
+
+      spec = %{
+        offset: 1,
+        limit: 1,
+        order_by: 0,
+        order: :asc
+      }
+
+      send(widget.pid, {:get_rows, self(), spec})
+
+      assert_receive {:rows,
+                      %{
+                        rows: [
+                          %{id: _, fields: %{0 => "2", 1 => ~s/"Terry Jeffords"/}}
+                        ],
+                        total_rows: 3,
+                        columns: [_, _]
+                      }}
+    end
+  end
+
+  defp connect_self(widget) do
+    send(widget.pid, {:connect, self()})
+    assert_receive {:connect_reply, %{}}
+  end
+end


### PR DESCRIPTION
This defines a new output type - an interactive data table. The client (Livebook) makes queries to the widget process to get rows (with optional support for pagination and sorting). For the output rendering see https://github.com/elixir-nx/livebook/pull/356.

Further, this defines `Kino.ETS` widget that adheres to the dynamic table communication protocol and makes for an interface for browsing an ETS table.

https://user-images.githubusercontent.com/17034772/122280192-3e213e80-cee9-11eb-8458-ab8caa5968d5.mp4

FTR: I think the widget shouldn't support deletion or any other kind of mutation and should be just a presentation layer. This way we force the user to document any relevant mutations as code in Elixir cells, which is in the spirit of reproducability.