### PR TITLE
Add image output and meta-struct

### DIFF
--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -10,7 +10,7 @@ defmodule Kino do
   an implementation is not available. The data structures supported
   by Kino out of the box are:
 
-  ### VegaLite widgets
+  ### VegaLite
 
   `VegaLite` specifications are rendered as visualizations:
 
@@ -18,7 +18,7 @@ defmodule Kino do
       |> Vl.data_from_series(...)
       |> ...
 
-  ### Kino.VegaLite widgets
+  ### Kino.VegaLite
 
   `Kino.VegaLite` is an extension of `VegaLite` that allows data to
   be streamed:
@@ -32,7 +32,7 @@ defmodule Kino do
 
       Kino.VegaLite.push(widget, %{x: 1, y: 2})
 
-  ### Kino.ETS widgets
+  ### Kino.ETS
 
   `Kino.ETS` implements a data table output for ETS tables in the
   system:
@@ -40,7 +40,7 @@ defmodule Kino do
       tid = :ets.new(:users, [:set, :public])
       Kino.ETS.start(tid)
 
-  ### Kino.DataTable widgets
+  ### Kino.DataTable
 
   `Kino.DataTable` implements a data table output for user-provided
   tabular data:
@@ -51,6 +51,14 @@ defmodule Kino do
       ]
 
       Kino.DataTable.start(data)
+
+  ### Kino.Image
+
+  `Kino.Image` wraps binary image content and can be used to render
+  raw images of any given format:
+
+      content = File.read!("/path/to/image.jpeg")
+      Kino.Image.new(content, "image/jpeg")
 
   ### All others
 

--- a/lib/kino/image.ex
+++ b/lib/kino/image.ex
@@ -1,0 +1,47 @@
+defmodule Kino.Image do
+  @moduledoc """
+  A struct wrapping a binary image.
+
+  This is just a meta-struct that implements the `Kino.Render`
+  protocol, so that it gets rendered as the underlying image.
+
+  ## Examples
+
+      content = File.read!("/path/to/image.jpeg")
+      Kino.Image.new(content, "image/jpeg")
+  """
+
+  @enforce_keys [:content, :mime_type]
+
+  defstruct [:content, :mime_type]
+
+  @type t :: %__MODULE__{
+          content: binary(),
+          mime_type: mime_type()
+        }
+
+  @type mime_type :: binary()
+  @type common_image_type :: :jpeg | :png | :gif | :svg
+
+  @doc """
+  Wraps the given binary content into the image struct.
+
+  The given type be either `:jpeg`, `:png`, `:gif`, `:svg`
+  or a string with image MIME type.
+  """
+  @spec new(binary(), common_image_type() | mime_type()) :: t()
+  def new(content, type) do
+    %__MODULE__{content: content, mime_type: mime_type!(type)}
+  end
+
+  defp mime_type!(:jpeg), do: "image/jpeg"
+  defp mime_type!(:png), do: "image/png"
+  defp mime_type!(:gif), do: "image/gif"
+  defp mime_type!(:svg), do: "image/svg+xml"
+  defp mime_type!("image/" <> _ = mime_type), do: mime_type
+
+  defp mime_type!(other) do
+    raise ArgumentError,
+          "expected image type to be either :jpeg, :png, :gif, :svg or an image MIME type string, got: #{inspect(other)}"
+  end
+end

--- a/lib/kino/output.ex
+++ b/lib/kino/output.ex
@@ -10,6 +10,7 @@ defmodule Kino.Output do
           ignored()
           | text_inline()
           | text_block()
+          | image()
           | vega_lite_static()
           | vega_lite_dynamic()
           | table_dynamic()
@@ -28,6 +29,11 @@ defmodule Kino.Output do
   Standalone text block.
   """
   @type text_block :: {:text, binary()}
+
+  @typedoc """
+  A raw image in the given format.
+  """
+  @type image :: {:image, content :: binary(), mime_type :: binary()}
 
   @typedoc """
   [Vega-Lite](https://vega.github.io/vega-lite) graphic.
@@ -128,6 +134,14 @@ defmodule Kino.Output do
   @spec text_block(binary()) :: t()
   def text_block(text) when is_binary(text) do
     {:text, text}
+  end
+
+  @doc """
+  See `t:image/0`.
+  """
+  @spec image(binary(), binary()) :: t()
+  def image(content, mime_type) when is_binary(content) and is_binary(mime_type) do
+    {:image, content, mime_type}
   end
 
   @doc """

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -38,6 +38,12 @@ defimpl Kino.Render, for: Kino.DataTable do
   end
 end
 
+defimpl Kino.Render, for: Kino.Image do
+  def to_livebook(image) do
+    Kino.Output.image(image.content, image.mime_type)
+  end
+end
+
 # Elixir built-ins
 
 defimpl Kino.Render, for: Reference do

--- a/test/kino/image_test.exs
+++ b/test/kino/image_test.exs
@@ -1,0 +1,25 @@
+defmodule Kino.ImageTest do
+  use ExUnit.Case, async: true
+
+  describe "new/2" do
+    test "raises an error for a non-image MIME type" do
+      assert_raise ArgumentError,
+                   "expected image type to be either :jpeg, :png, :gif, :svg or an image MIME type string, got: \"application/json\"",
+                   fn ->
+                     Kino.Image.new(<<>>, "application/json")
+                   end
+    end
+
+    test "raises an error for an invalid type shorthand" do
+      assert_raise ArgumentError,
+                   "expected image type to be either :jpeg, :png, :gif, :svg or an image MIME type string, got: :invalid",
+                   fn ->
+                     Kino.Image.new(<<>>, :invalid)
+                   end
+    end
+
+    test "converts a valid type shorthand into MIME type" do
+      assert %{mime_type: "image/jpeg"} = Kino.Image.new(<<>>, :jpeg)
+    end
+  end
+end


### PR DESCRIPTION
Defines a new output type - raw image, and also introduces a simple `%Kino.Image{}` struct that implements the `Kino.Render` protocol and is thus automatically rendered as an image.

https://user-images.githubusercontent.com/17034772/122954271-950e9400-d37f-11eb-9e8e-e3cc13a94d73.mp4