### PR TITLE
Start dynamic widgets with new for consistency

### DIFF
--- a/lib/kino.ex
+++ b/lib/kino.ex
@@ -27,7 +27,7 @@ defmodule Kino do
         Vl.new(...)
         |> Vl.data_from_series(...)
         |> ...
-        |> Kino.VegaLite.start()
+        |> Kino.VegaLite.new()
         |> Kino.render()
 
       Kino.VegaLite.push(widget, %{x: 1, y: 2})
@@ -38,7 +38,7 @@ defmodule Kino do
   system:
 
       tid = :ets.new(:users, [:set, :public])
-      Kino.ETS.start(tid)
+      Kino.ETS.new(tid)
 
   ### Kino.DataTable
 
@@ -50,7 +50,7 @@ defmodule Kino do
         %{id: 2, name: "Erlang", website: "https://www.erlang.org"}
       ]
 
-      Kino.DataTable.start(data)
+      Kino.DataTable.new(data)
 
   ### Kino.Image
 

--- a/lib/kino/data_table.ex
+++ b/lib/kino/data_table.ex
@@ -13,14 +13,14 @@ defmodule Kino.DataTable do
         %{id: 2, name: "Erlang", website: "https://www.erlang.org"}
       ]
 
-      Kino.DataTable.start(data)
+      Kino.DataTable.new(data)
 
   The tabular view allows you to quickly preview the data
   and analyze it thanks to sorting capabilities.
 
       data = Process.list() |> Enum.map(&Process.info/1)
 
-      Kino.DataTable.start(
+      Kino.DataTable.new(
         data,
         keys: [:registered_name, :initial_call, :reductions, :stack_size]
       )
@@ -53,8 +53,8 @@ defmodule Kino.DataTable do
       desirable for lazy enumerables. Defaults to `true` if data is a list
       and `false` otherwise.
   """
-  @spec start(Enum.t(), keyword()) :: t()
-  def start(data, opts \\ []) do
+  @spec new(Enum.t(), keyword()) :: t()
+  def new(data, opts \\ []) do
     validate_data!(data)
 
     parent = self()
@@ -66,6 +66,10 @@ defmodule Kino.DataTable do
 
     %__MODULE__{pid: pid}
   end
+
+  # TODO: remove in v0.3.0
+  @deprecated "Use Kino.DataTable.new/2 instead"
+  def start(data, opts \\ []), do: new(data, opts)
 
   # Validate data only if we have a whole list upfront
   defp validate_data!(data) when is_list(data) do

--- a/lib/kino/ets.ex
+++ b/lib/kino/ets.ex
@@ -5,9 +5,9 @@ defmodule Kino.ETS do
   ## Examples
 
       tid = :ets.new(:users, [:set, :public])
-      Kino.ETS.start(tid)
+      Kino.ETS.new(tid)
 
-      Kino.ETS.start(:elixir_config)
+      Kino.ETS.new(:elixir_config)
   """
 
   use GenServer, restart: :temporary
@@ -28,8 +28,8 @@ defmodule Kino.ETS do
   Note that private tables cannot be read by an arbitrary process,
   so the given table must have either public or protected access.
   """
-  @spec start(:ets.tid()) :: t()
-  def start(tid) do
+  @spec new(:ets.tid()) :: t()
+  def new(tid) do
     case :ets.info(tid, :protection) do
       :private ->
         raise ArgumentError,
@@ -50,6 +50,10 @@ defmodule Kino.ETS do
 
     %__MODULE__{pid: pid}
   end
+
+  # TODO: remove in v0.3.0
+  @deprecated "Use Kino.ETS.new/1 instead"
+  def start(tid), do: new(tid)
 
   @doc false
   def start_link(opts) do

--- a/lib/kino/render.ex
+++ b/lib/kino/render.ex
@@ -50,7 +50,7 @@ defimpl Kino.Render, for: Reference do
   def to_livebook(reference) do
     cond do
       accessible_ets_table?(reference) ->
-        reference |> Kino.ETS.start() |> Kino.Render.to_livebook()
+        reference |> Kino.ETS.new() |> Kino.Render.to_livebook()
 
       true ->
         Kino.Output.inspect(reference)

--- a/lib/kino/vega_lite.ex
+++ b/lib/kino/vega_lite.ex
@@ -12,7 +12,7 @@ defmodule Kino.VegaLite do
         |> Vl.mark(:line)
         |> Vl.encode_field(:x, "x", type: :quantitative)
         |> Vl.encode_field(:y, "y", type: :quantitative)
-        |> Kino.VegaLite.start()
+        |> Kino.VegaLite.new()
         |> Kino.render()
 
       for i <- 1..300 do
@@ -40,8 +40,8 @@ defmodule Kino.VegaLite do
   @doc """
   Starts a widget process with the given VegaLite definition.
   """
-  @spec start(VegaLite.t()) :: t()
-  def start(vl) when is_struct(vl, VegaLite) do
+  @spec new(VegaLite.t()) :: t()
+  def new(vl) when is_struct(vl, VegaLite) do
     parent = self()
     opts = [vl: vl, parent: parent]
 
@@ -49,6 +49,10 @@ defmodule Kino.VegaLite do
 
     %__MODULE__{pid: pid}
   end
+
+  # TODO: remove in v0.3.0
+  @deprecated "Use Kino.VegaLite.new/1 instead"
+  def start(vl), do: new(vl)
 
   @doc false
   def start_link(opts) do

--- a/test/kino/data_table_test.exs
+++ b/test/kino/data_table_test.exs
@@ -1,12 +1,12 @@
 defmodule Kino.DataTableTest do
   use ExUnit.Case, async: true
 
-  describe "start/1" do
+  describe "new/1" do
     test "raises an error when structs are given" do
       assert_raise ArgumentError,
                    "struct records are not supported, you need to convert them to maps explicitly",
                    fn ->
-                     Kino.DataTable.start([
+                     Kino.DataTable.new([
                        URI.parse("https://elixir-lang.org"),
                        URI.parse("https://www.erlang.org")
                      ])
@@ -17,7 +17,7 @@ defmodule Kino.DataTableTest do
       assert_raise ArgumentError,
                    "expected record to be either map, tuple or keyword list, got: \"value\"",
                    fn ->
-                     Kino.DataTable.start(["value"])
+                     Kino.DataTable.new(["value"])
                    end
     end
 
@@ -25,13 +25,13 @@ defmodule Kino.DataTableTest do
       assert_raise ArgumentError,
                    "expected records to have the same data type, found map and tuple",
                    fn ->
-                     Kino.DataTable.start([%{id: 1, name: "Grumpy"}, {2, "Lil Bub"}])
+                     Kino.DataTable.new([%{id: 1, name: "Grumpy"}, {2, "Lil Bub"}])
                    end
     end
 
     test "does not validate enumerables other than list" do
       data = MapSet.new([%{id: 1, name: "Grumpy"}, {2, "Lil Bub"}])
-      Kino.DataTable.start(data)
+      Kino.DataTable.new(data)
     end
   end
 
@@ -43,7 +43,7 @@ defmodule Kino.DataTableTest do
 
   describe "connecting" do
     test "connect reply contains empty columns definition if the :keys option is not given" do
-      widget = Kino.DataTable.start(@people_data)
+      widget = Kino.DataTable.new(@people_data)
 
       send(widget.pid, {:connect, self()})
 
@@ -51,7 +51,7 @@ defmodule Kino.DataTableTest do
     end
 
     test "connect reply contains columns definition if the :keys option is given" do
-      widget = Kino.DataTable.start(@people_data, keys: [:id, :name])
+      widget = Kino.DataTable.new(@people_data, keys: [:id, :name])
 
       send(widget.pid, {:connect, self()})
 
@@ -63,7 +63,7 @@ defmodule Kino.DataTableTest do
     end
 
     test "sorting is enabled by default when a list is given" do
-      widget = Kino.DataTable.start([])
+      widget = Kino.DataTable.new([])
 
       send(widget.pid, {:connect, self()})
 
@@ -71,7 +71,7 @@ defmodule Kino.DataTableTest do
     end
 
     test "sorting is disabled by default when non-list is given" do
-      widget = Kino.DataTable.start(MapSet.new())
+      widget = Kino.DataTable.new(MapSet.new())
 
       send(widget.pid, {:connect, self()})
 
@@ -79,7 +79,7 @@ defmodule Kino.DataTableTest do
     end
 
     test "sorting is enabled when set explicitly with :enable_sorting" do
-      widget = Kino.DataTable.start(MapSet.new(), sorting_enabled: true)
+      widget = Kino.DataTable.new(MapSet.new(), sorting_enabled: true)
 
       send(widget.pid, {:connect, self()})
 
@@ -96,7 +96,7 @@ defmodule Kino.DataTableTest do
         [b: 2, a: 2]
       ]
 
-      widget = Kino.DataTable.start(data)
+      widget = Kino.DataTable.new(data)
       connect_self(widget)
 
       send(widget.pid, {:get_rows, self(), @default_rows_spec})
@@ -113,7 +113,7 @@ defmodule Kino.DataTableTest do
         %{b: 2, c: 2}
       ]
 
-      widget = Kino.DataTable.start(data)
+      widget = Kino.DataTable.new(data)
       connect_self(widget)
 
       send(widget.pid, {:get_rows, self(), @default_rows_spec})
@@ -135,7 +135,7 @@ defmodule Kino.DataTableTest do
         {3}
       ]
 
-      widget = Kino.DataTable.start(data)
+      widget = Kino.DataTable.new(data)
       connect_self(widget)
 
       send(widget.pid, {:get_rows, self(), @default_rows_spec})
@@ -152,7 +152,7 @@ defmodule Kino.DataTableTest do
     end
 
     test "columns are reused if the :keys option is given" do
-      widget = Kino.DataTable.start(@people_data, keys: [:name])
+      widget = Kino.DataTable.new(@people_data, keys: [:name])
       connect_self(widget)
 
       send(widget.pid, {:get_rows, self(), @default_rows_spec})
@@ -161,7 +161,7 @@ defmodule Kino.DataTableTest do
     end
 
     test "preserves data order by default" do
-      widget = Kino.DataTable.start(@people_data)
+      widget = Kino.DataTable.new(@people_data)
       connect_self(widget)
 
       spec = %{
@@ -186,7 +186,7 @@ defmodule Kino.DataTableTest do
     end
 
     test "supports sorting by other columns" do
-      widget = Kino.DataTable.start(@people_data)
+      widget = Kino.DataTable.new(@people_data)
       connect_self(widget)
 
       spec = %{
@@ -211,7 +211,7 @@ defmodule Kino.DataTableTest do
     end
 
     test "supports offset and limit" do
-      widget = Kino.DataTable.start(@people_data)
+      widget = Kino.DataTable.new(@people_data)
       connect_self(widget)
 
       spec = %{
@@ -234,7 +234,7 @@ defmodule Kino.DataTableTest do
     end
 
     test "sends only relevant fields if user-specified keys are given" do
-      widget = Kino.DataTable.start(@people_data, keys: [:id])
+      widget = Kino.DataTable.new(@people_data, keys: [:id])
       connect_self(widget)
 
       spec = %{

--- a/test/kino/ets_test.exs
+++ b/test/kino/ets_test.exs
@@ -1,14 +1,14 @@
 defmodule Kino.ETSTest do
   use ExUnit.Case, async: true
 
-  describe "start/1" do
+  describe "new/1" do
     test "raises an error when private table is given" do
       tid = :ets.new(:users, [:set, :private])
 
       assert_raise ArgumentError,
                    "the given table must be either public or protected, but a private one was given",
                    fn ->
-                     Kino.ETS.start(tid)
+                     Kino.ETS.new(tid)
                    end
     end
 
@@ -19,7 +19,7 @@ defmodule Kino.ETSTest do
       assert_raise ArgumentError,
                    "the given table identifier #{inspect(tid)} does not refer to an existing ETS table",
                    fn ->
-                     Kino.ETS.start(tid)
+                     Kino.ETS.new(tid)
                    end
     end
   end
@@ -28,7 +28,7 @@ defmodule Kino.ETSTest do
     test "connect reply contains empty columns definition if there are no records" do
       tid = :ets.new(:users, [:set, :public])
 
-      widget = Kino.ETS.start(tid)
+      widget = Kino.ETS.new(tid)
 
       send(widget.pid, {:connect, self()})
 
@@ -39,7 +39,7 @@ defmodule Kino.ETSTest do
       tid = :ets.new(:users, [:set, :public])
       :ets.insert(tid, {1, "Terry Jeffords"})
 
-      widget = Kino.ETS.start(tid)
+      widget = Kino.ETS.new(tid)
 
       send(widget.pid, {:connect, self()})
 
@@ -63,7 +63,7 @@ defmodule Kino.ETSTest do
     end
 
     test "replies with records and total rows", %{tid: tid} do
-      widget = Kino.ETS.start(tid)
+      widget = Kino.ETS.new(tid)
       connect_self(widget)
 
       spec = %{
@@ -88,7 +88,7 @@ defmodule Kino.ETSTest do
     end
 
     test "supports offset and limit", %{tid: tid} do
-      widget = Kino.ETS.start(tid)
+      widget = Kino.ETS.new(tid)
       connect_self(widget)
 
       spec = %{
@@ -115,7 +115,7 @@ defmodule Kino.ETSTest do
       :ets.insert(tid, {5, "John Watson", 150, :doctor})
       :ets.insert(tid, {6})
 
-      widget = Kino.ETS.start(tid)
+      widget = Kino.ETS.new(tid)
       connect_self(widget)
 
       spec = %{

--- a/test/kino/vega_lite_test.exs
+++ b/test/kino/vega_lite_test.exs
@@ -136,7 +136,7 @@ defmodule Kino.VegaLiteTest do
     |> Vl.mark(:point)
     |> Vl.encode_field(:x, "x", type: :quantitative)
     |> Vl.encode_field(:y, "y", type: :quantitative)
-    |> Kino.VegaLite.start()
+    |> Kino.VegaLite.new()
   end
 
   defp connect_self(widget) do


### PR DESCRIPTION
Renaming all `Kino.SomeDynamicWidget.start(...)` to `Kino.SomeDynamicWidget.new(...)` to make it transparent whether the widget is a stateful process or a static struct.